### PR TITLE
Improve image accessibility and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ REACT_APP_MAKE_WEBHOOK=https://seu-webhook.aqui
 ### 🔍 Otimização de Performance
 
 - [ ] Converter imagens para WebP com compressão eficiente
-- [ ] Aplicar lazy loading nas imagens (`loading="lazy"`)
+ - [x] Aplicar lazy loading nas imagens (`loading="lazy"`)
 - [x] Revisar uso de fontes externas
 - [x] Minificar e limpar arquivos CSS/JS não utilizados
 - [x] Ativar cache e compressão na hospedagem
@@ -38,7 +38,7 @@ REACT_APP_MAKE_WEBHOOK=https://seu-webhook.aqui
 ### 🧠 Acessibilidade e SEO
 
 - [x] Atualizar `title`, `meta description` e tags de redes sociais
-- [ ] Atualizar tags `alt` nas imagens
+ - [x] Atualizar tags `alt` nas imagens
 - [ ] Revisar estrutura HTML para melhorar acessibilidade
 - [ ] Otimizar estrutura de arquivos para melhor SEO
 

--- a/src/components/secoes/Hero.tsx
+++ b/src/components/secoes/Hero.tsx
@@ -8,19 +8,22 @@ export default function Hero() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="./images/hero/hero.png"
         alt="Pessoa com chapéu de palha sentada em uma mesa no meio do mar raso, escrevendo em um caderno. Ao fundo, o céu azul e o horizonte. Texto na imagem diz 'Bossa Eco Luxury Villa - E, afinal, quem sou? Eu estou no encontro do mangue com mar', abaixo um botão escrito: saiba mais!."
+        loading="lazy"
       />
  
       <div className="relative z-10 flex flex-col h-full items-center justify-between py-24">
         <img
           className="w-74 md:w-96"
           src="./images/hero/logoTaipa.png"
-          alt=""
+          alt="Logo Bossa Eco Luxury Villa"
+          loading="lazy"
         />
         <div className="flex flex-col items-center gap-8">
           <img
             src="./images/carouselHero/fraseUm.png"
             className="w-1/2 sm:w-3/4"
-            alt=""
+            alt="Trecho motivacional decorativo"
+            loading="lazy"
           />
           <Button href="#contato" className="text-white w-1/2 ">Saiba mais!</Button>
         </div>

--- a/src/components/secoes/SecaoCinco.tsx
+++ b/src/components/secoes/SecaoCinco.tsx
@@ -5,6 +5,7 @@ export default function SecaoCinco() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoCinco/SecaoCincoBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl flex w-full h-full my-32 flex-col items-center justify-center">
@@ -14,11 +15,13 @@ export default function SecaoCinco() {
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2"
             src="/images/secaoCinco/secaoCincoTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <img
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 rounded-md"
             src="/images/secaoCinco/secaoCincoImgDois.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoDez.tsx
+++ b/src/components/secoes/SecaoDez.tsx
@@ -16,6 +16,7 @@ export default function SecaoSeis() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoDez/secaoDezBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl px-8 flex w-full h-full my-32 flex-col items-center justify-center">

--- a/src/components/secoes/SecaoDois.tsx
+++ b/src/components/secoes/SecaoDois.tsx
@@ -4,7 +4,8 @@ export default function SecaoDois() {
       <img
         className=""
         src="./images/secaoDois/secaoDoisBG.png"
-        alt="Home sentado em uma cadeira, desenhando o projeto em um papel"
+        alt="Homem sentado em uma cadeira, desenhando o projeto em um papel"
+        loading="lazy"
       />
     </div>
   );

--- a/src/components/secoes/SecaoDoze.tsx
+++ b/src/components/secoes/SecaoDoze.tsx
@@ -6,6 +6,7 @@ export default function SecaoDoze() {
           className="absolute inset-0 w-full h-full object-cover z-0"
           src="/images/secaoDoze/SecaoDozeBG.png"
           alt="Plano de fundo verde texturizado"
+          loading="lazy"
         />
 
         <div className="relative z-10 max-w-6xl px-8 flex w-full h-full my-32 flex-col items-center justify-center">
@@ -13,6 +14,7 @@ export default function SecaoDoze() {
             className="w-full h-full object-cover rounded-md"
             src="/images/secaoDoze/secaoDozeImagem.png"
             alt="Homem sentado em uma cadeira, desenhando o projeto em um papel"
+            loading="lazy"
           />
         </div>
       </section>

--- a/src/components/secoes/SecaoNove.tsx
+++ b/src/components/secoes/SecaoNove.tsx
@@ -5,6 +5,7 @@ export default function SecaoSeis() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoNove/SecaoNoveBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl px-8 flex w-full h-full my-32 flex-col items-center justify-center">
@@ -14,11 +15,13 @@ export default function SecaoSeis() {
             className="w-full md:w-2/3 lg:w-1/2 xl:w-3/4"
             src="/images/secaoNove/secaoNoveTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <img
             className="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-full rounded-md"
             src="/images/secaoNove/secaoNoveFoto.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoOito.tsx
+++ b/src/components/secoes/SecaoOito.tsx
@@ -5,6 +5,7 @@ export default function SecaoSeis() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoOito/secaoOitoBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl flex w-full h-full my-32 flex-col items-center justify-center">
@@ -14,11 +15,13 @@ export default function SecaoSeis() {
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2"
             src="/images/secaoOito/secaoOitoTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <img
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 rounded-md"
             src="/images/secaoOito/secaoOitoFotos.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoOnze.tsx
+++ b/src/components/secoes/SecaoOnze.tsx
@@ -7,6 +7,7 @@ export default function SecaoDoze() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoOnze/SecaoOnzeBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl px-8 gap-16 flex w-full h-full my-32 flex-col items-center justify-center">

--- a/src/components/secoes/SecaoQuatorze.tsx
+++ b/src/components/secoes/SecaoQuatorze.tsx
@@ -5,6 +5,7 @@ export default function SecaoQuatroze() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoDoze/SecaoDozeBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl px-8 flex w-full h-full my-32 flex-col items-center justify-center">
@@ -13,6 +14,7 @@ export default function SecaoQuatroze() {
             className="w-full md:w-2/3 lg:w-1/2 xl:w-3/4"
             src="/images/secaoQuatorze/secaoQuatorzeSelos.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoQuatro.tsx
+++ b/src/components/secoes/SecaoQuatro.tsx
@@ -19,6 +19,7 @@ export default function SecaoQuatro() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoQuatro/SecaoQuatroBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 w-full py-32 px-8 flex flex-col items-center gap-24 justify-center">
@@ -27,6 +28,7 @@ export default function SecaoQuatro() {
             className="w-2/4 md:w-2/3 lg:w-1/2 xl:w-1/3"
             src="/images/secaoQuatro/SecaoQuatroTextoUm.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <div className="w-full">
             <Iframe videoId={"NOXS2mt86bo"} />
@@ -38,6 +40,7 @@ export default function SecaoQuatro() {
             className="w-2/4 md:w-2/3 lg:w-1/2 xl:w-1/2"
             src="/images/secaoQuatro/SecaoQuatroTextoDois.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
           <Carousel images={imagensSecaoQuatro} altTextPrefix="" />
         </article>
@@ -48,6 +51,7 @@ export default function SecaoQuatro() {
               className="w-xl md:w-2/3 lg:w-full xl:w-full"
               src="/images/secaoQuatro/SecaoQuatroTextoTres.png"
               alt="Conclusão da seção"
+              loading="lazy"
             />
             <Button href="#contato">Saiba mais!</Button>
           </div>

--- a/src/components/secoes/SecaoQuinze.tsx
+++ b/src/components/secoes/SecaoQuinze.tsx
@@ -5,6 +5,7 @@ export default function SecaoQuinze() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoNove/SecaoNoveBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl px-8 flex w-full h-full my-32 flex-col items-center justify-center">
@@ -13,6 +14,7 @@ export default function SecaoQuinze() {
             className="w-full md:w-2/3 lg:w-1/2 xl:w-3/4"
             src="/images/secaoQuinze/secaoQuinzeImagemTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoSeis.tsx
+++ b/src/components/secoes/SecaoSeis.tsx
@@ -5,6 +5,7 @@ export default function SecaoSeis() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoSeis/SecaoSeisBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl flex w-full h-full my-32 flex-col items-center justify-center">
@@ -14,11 +15,13 @@ export default function SecaoSeis() {
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2"
             src="/images/secaoSeis/secaoSeisTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <img
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 rounded-md"
             src="/images/secaoSeis/SecaoSeisFotos.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoSete.tsx
+++ b/src/components/secoes/SecaoSete.tsx
@@ -5,6 +5,7 @@ export default function SecaoSeis() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoSete/SecaoSeteBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl flex w-full h-full my-32 flex-col items-center justify-center">
@@ -14,11 +15,13 @@ export default function SecaoSeis() {
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 rounded-md"
             src="/images/secaoSete/SecaoSeteFotos.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
           <img
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2"
             src="/images/secaoSete/secaoSeteTexto.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
         </article>
       </div>

--- a/src/components/secoes/SecaoTres.tsx
+++ b/src/components/secoes/SecaoTres.tsx
@@ -11,7 +11,8 @@ export default function SecaoTres() {
         <img
           className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-1/2"
           src="./images/secaoTres/SecaoTresTexto.png"
-          alt=""
+          alt="Descrição da Bossa Eco Luxury Villas"
+          loading="lazy"
         />
       </div>
     </section>

--- a/src/components/secoes/SecaoTreze.tsx
+++ b/src/components/secoes/SecaoTreze.tsx
@@ -5,6 +5,7 @@ export default function SecaoTreze() {
         className="absolute inset-0 w-full h-full object-cover z-0"
         src="/images/secaoOito/secaoOitoBG.png"
         alt="Plano de fundo verde texturizado"
+        loading="lazy"
       />
 
       <div className="relative z-10 max-w-6xl flex w-full h-full my-32 flex-col items-center justify-center">
@@ -13,11 +14,13 @@ export default function SecaoTreze() {
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2"
             src="/images/secaoTreze/secaoTrezeTextoImagem.png"
             alt="Explicação sobre o vídeo"
+            loading="lazy"
           />
           <img
             className="w-3/4 sm:w-3/4 md:w-2/3 lg:w-1/2 rounded-md"
             src="/images/secaoTreze/secaoTrezeImagem.png"
             alt="Descrição da galeria de imagens"
+            loading="lazy"
           />
         </article>
       </div>


### PR DESCRIPTION
## Summary
- enable lazy loading on all sections images
- add missing alt text
- check off README tasks about lazy loading and alt attributes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68472dd6e8708320a21121557450e344